### PR TITLE
{player} placeholder fixed when leader is offline

### DIFF
--- a/src/main/java/com/bgsoftware/ssboneblock/actions/Action.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/actions/Action.java
@@ -4,6 +4,7 @@ import com.bgsoftware.ssboneblock.OneBlockModule;
 import com.bgsoftware.superiorskyblock.api.island.Island;
 import com.bgsoftware.superiorskyblock.api.wrappers.BlockOffset;
 import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
 import javax.annotation.Nullable;
@@ -19,6 +20,6 @@ public abstract class Action {
         this.offsetPosition = offsetPosition;
     }
 
-    public abstract void run(Location location, Island island, Player player);
+    public abstract void run(Location location, Island island, OfflinePlayer player);
 
 }

--- a/src/main/java/com/bgsoftware/ssboneblock/actions/CommandAction.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/actions/CommandAction.java
@@ -10,6 +10,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
 import javax.annotation.Nullable;
@@ -27,13 +28,12 @@ public final class CommandAction extends Action {
     }
 
     @Override
-    public void run(Location location, Island island, Player player) {
+    public void run(Location location, Island island, OfflinePlayer player) {
         if (offsetPosition != null)
             location = offsetPosition.applyToLocation(location);
-
         for (String command : commands) {
             Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command
-                    .replace("{player}", player == null ? "null" : player.getName())
+                    .replace("{player}", player  == null ? "null" : player.getName())
                     .replace("{world}", location.getWorld().getName())
                     .replace("{x}", location.getBlockX() + "")
                     .replace("{y}", location.getBlockY() + "")

--- a/src/main/java/com/bgsoftware/ssboneblock/actions/MultiAction.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/actions/MultiAction.java
@@ -2,6 +2,7 @@ package com.bgsoftware.ssboneblock.actions;
 
 import com.bgsoftware.superiorskyblock.api.island.Island;
 import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
 public final class MultiAction extends Action {
@@ -14,7 +15,7 @@ public final class MultiAction extends Action {
     }
 
     @Override
-    public void run(Location location, Island island, Player player) {
+    public void run(Location location, Island island, OfflinePlayer player) {
         for (Action action : actions)
             action.run(location, island, player);
     }

--- a/src/main/java/com/bgsoftware/ssboneblock/actions/RandomAction.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/actions/RandomAction.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
 import java.util.Optional;
@@ -24,7 +25,7 @@ public final class RandomAction extends Action {
     }
 
     @Override
-    public void run(Location location, Island island, Player player) {
+    public void run(Location location, Island island, OfflinePlayer player) {
         if (possibilities.length > 0)
             possibilities[ThreadLocalRandom.current().nextInt(possibilities.length)].run(location, island, player);
     }

--- a/src/main/java/com/bgsoftware/ssboneblock/actions/SetBlockAction.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/actions/SetBlockAction.java
@@ -12,6 +12,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
@@ -35,7 +36,7 @@ public final class SetBlockAction extends Action {
     }
 
     @Override
-    public void run(Location location, Island island, Player player) {
+    public void run(Location location, Island island, OfflinePlayer player) {
         if (offsetPosition != null)
             location = offsetPosition.applyToLocation(location);
 

--- a/src/main/java/com/bgsoftware/ssboneblock/actions/SpawnEntityAction.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/actions/SpawnEntityAction.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
@@ -29,7 +30,7 @@ public final class SpawnEntityAction extends Action {
     }
 
     @Override
-    public void run(Location location, Island island, Player player) {
+    public void run(Location location, Island island, OfflinePlayer player) {
         if (offsetPosition != null)
             location = offsetPosition.applyToLocation(location);
 

--- a/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdSetPhase.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdSetPhase.java
@@ -68,8 +68,7 @@ public final class CmdSetPhase implements ICommand {
             Message.INVALID_NUMBER.send(sender, args[2]);
             return;
         }
-
-        if (phaseLevel <= 0 || !plugin.getPhasesHandler().setPhaseLevel(island, phaseLevel - 1, island.getOwner().asPlayer())) {
+        if (phaseLevel <= 0 || !plugin.getPhasesHandler().setPhaseLevel(island, phaseLevel - 1, island.getOwner().asOfflinePlayer())) {
             Message.SET_PHASE_FAILURE.send(sender, phaseLevel);
         } else {
             Message.SET_PHASE_SUCCESS.send(sender, args[1], phaseLevel);

--- a/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdSetPhaseBlock.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdSetPhaseBlock.java
@@ -69,7 +69,7 @@ public final class CmdSetPhaseBlock implements ICommand {
             return;
         }
 
-        if(phaseBlock <= 0 || !plugin.getPhasesHandler().setPhaseBlock(island, phaseBlock - 1, island.getOwner().asPlayer())){
+        if(phaseBlock <= 0 || !plugin.getPhasesHandler().setPhaseBlock(island, phaseBlock - 1, island.getOwner().asOfflinePlayer())){
             Message.SET_PHASE_BLOCK_FAILURE.send(sender, phaseBlock);
         }
         else{

--- a/src/main/java/com/bgsoftware/ssboneblock/listeners/IslandsListener.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/listeners/IslandsListener.java
@@ -23,7 +23,7 @@ public final class IslandsListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onIslandCreate(IslandCreateEvent e) {
         if (plugin.getPhasesHandler().canHaveOneBlock(e.getIsland()))
-            plugin.getPhasesHandler().runNextAction(e.getIsland(), e.getPlayer().asPlayer());
+            plugin.getPhasesHandler().runNextAction(e.getIsland(), e.getPlayer().asOfflinePlayer());
     }
 
 


### PR DESCRIPTION
I fixed the issue when `{player}` placeholder would return `null` if leader of the island is offline. Fixed issue #95 

Key changes include:

### Method Signature Updates:
* [`src/main/java/com/bgsoftware/ssboneblock/actions/Action.java`](diffhunk://#diff-3b079fcc9c4500580e036bb1367a406214eb6c6084781152c0de569c4b013b63L22-R23): Updated the `run` method to accept `OfflinePlayer` instead of `Player`.
* [`src/main/java/com/bgsoftware/ssboneblock/actions/CommandAction.java`](diffhunk://#diff-53f95de3ac771fc7f6e4569a8b1d4f08ce44a37756320d2f8d98da4134d7d057L30-L33): Updated the `run` method to accept `OfflinePlayer` instead of `Player`.
* [`src/main/java/com/bgsoftware/ssboneblock/actions/MultiAction.java`](diffhunk://#diff-6ec382d7ac994955402824b0680f4f57eb3732343efb49222e3f18c340144a01L17-R18): Updated the `run` method to accept `OfflinePlayer` instead of `Player`.
* [`src/main/java/com/bgsoftware/ssboneblock/actions/RandomAction.java`](diffhunk://#diff-bc2d6d6053c11de3dc8304a023a0905d93ee212c380db542d566ceb9a8d96b09L27-R28): Updated the `run` method to accept `OfflinePlayer` instead of `Player`.
* [`src/main/java/com/bgsoftware/ssboneblock/actions/SetBlockAction.java`](diffhunk://#diff-2ecab48992082cb042b42b3f6782a65a2574c708f5d874e566d6db7b748d499bL38-R39): Updated the `run` method to accept `OfflinePlayer` instead of `Player`.
* [`src/main/java/com/bgsoftware/ssboneblock/actions/SpawnEntityAction.java`](diffhunk://#diff-7a544d8a003169bc6a85fedb5ad001b9c7610b4a547ef02949b9dd11f31d39f5L32-R33): Updated the `run` method to accept `OfflinePlayer` instead of `Player`.

### Command Handling:
* [`src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdSetPhase.java`](diffhunk://#diff-09eb554d17078f621cfc1549f9f20bbb3cdb235b630e694f6777acad6038cdb8L71-R71): Changed the `setPhaseLevel` method to use `asOfflinePlayer` for the island owner.
* [`src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdSetPhaseBlock.java`](diffhunk://#diff-5d586d3b054e96b47c712694381c494faeea5b5cbbf68d4e0357afc8c8c4db9fL72-R72): Changed the `setPhaseBlock` method to use `asOfflinePlayer` for the island owner.

### Phase Handling:
* [`src/main/java/com/bgsoftware/ssboneblock/handler/PhasesHandler.java`](diffhunk://#diff-c5338bee54fc4d9de3df12e0f88d9243f13ab423859da7f6a2901912e33c7775L56-R67): Updated various methods to use `OfflinePlayer` instead of `Player`, including `runNextAction`, `runNextActionTimer`, `setPhaseLevel`, and `setPhaseBlock`. [[1]](diffhunk://#diff-c5338bee54fc4d9de3df12e0f88d9243f13ab423859da7f6a2901912e33c7775L56-R67) [[2]](diffhunk://#diff-c5338bee54fc4d9de3df12e0f88d9243f13ab423859da7f6a2901912e33c7775L92-R108) [[3]](diffhunk://#diff-c5338bee54fc4d9de3df12e0f88d9243f13ab423859da7f6a2901912e33c7775L115-R129)

### Event Handling:
* [`src/main/java/com/bgsoftware/ssboneblock/listeners/IslandsListener.java`](diffhunk://#diff-b7d80413ed0f0bed988c78404b6226f479041dc47ca118f340b47d1f7330a9ecL26-R26): Changed the `runNextAction` call to use `asOfflinePlayer` for the player.