### PR TITLE
Fixed commands and messages

### DIFF
--- a/src/main/java/com/bgsoftware/ssboneblock/commands/CommandsHandler.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/commands/CommandsHandler.java
@@ -6,6 +6,7 @@ import com.bgsoftware.ssboneblock.commands.commands.CmdReload;
 import com.bgsoftware.ssboneblock.commands.commands.CmdSave;
 import com.bgsoftware.ssboneblock.commands.commands.CmdSetPhase;
 import com.bgsoftware.ssboneblock.commands.commands.CmdSetPhaseBlock;
+import com.bgsoftware.ssboneblock.lang.LocaleUtils;
 import com.bgsoftware.ssboneblock.lang.Message;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -35,6 +36,8 @@ public final class CommandsHandler extends Command {
 
     @Override
     public boolean execute(CommandSender sender, String label, String[] args) {
+        java.util.Locale locale = LocaleUtils.getLocale(sender);
+
         if (args.length > 0) {
             for (ICommand subCommand : subCommands) {
                 if (subCommand.getLabel().equalsIgnoreCase(args[0])) {
@@ -43,7 +46,7 @@ public final class CommandsHandler extends Command {
                         return false;
                     }
                     if (args.length < subCommand.getMinArgs() || args.length > subCommand.getMaxArgs()) {
-                        Message.COMMAND_USAGE.send(sender, subCommand.getUsage());
+                        Message.COMMAND_USAGE.send(sender, label + " " + subCommand.getUsage(locale));
                         return false;
                     }
                     subCommand.perform(module, sender, args);
@@ -60,7 +63,7 @@ public final class CommandsHandler extends Command {
 
                 for (ICommand cmd : subCommands) {
                     if (sender.hasPermission(subCommand.getPermission()))
-                        Message.HELP_COMMAND_LINE.send(sender, cmd.getUsage(), cmd.getDescription());
+                        Message.HELP_COMMAND_LINE.send(sender, label + " " + cmd.getUsage(locale), cmd.getDescription(locale));
                 }
 
                 Message.HELP_COMMAND_FOOTER.send(sender);

--- a/src/main/java/com/bgsoftware/ssboneblock/commands/ICommand.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/commands/ICommand.java
@@ -9,11 +9,11 @@ public interface ICommand {
 
     String getLabel();
 
-    String getUsage();
+    String getUsage(java.util.Locale locale);
 
     String getPermission();
 
-    String getDescription();
+    String getDescription(java.util.Locale locale);
 
     int getMinArgs();
 

--- a/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdCheck.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdCheck.java
@@ -23,8 +23,10 @@ public final class CmdCheck implements ICommand {
     }
 
     @Override
-    public String getUsage() {
-        return "oneblock check [player-name/island-name]";
+    public String getUsage(java.util.Locale locale) {
+        return "check [" +
+                Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
+                Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "]";
     }
 
     @Override
@@ -33,8 +35,8 @@ public final class CmdCheck implements ICommand {
     }
 
     @Override
-    public String getDescription() {
-        return "Check progress of a player.";
+    public String getDescription(java.util.Locale locale) {
+        return Message.COMMAND_DESCRIPTION_CHECK.getMessage(locale);
     }
 
     @Override
@@ -62,7 +64,7 @@ public final class CmdCheck implements ICommand {
 
         if (args.length == 1) {
             if (!(sender instanceof Player)) {
-                sender.sendMessage(ChatColor.RED + "Please specify a player you want to check.");
+                sender.sendMessage(ChatColor.RED + "You must specify a player's name.");
                 return;
             }
 

--- a/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdReload.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdReload.java
@@ -3,7 +3,6 @@ package com.bgsoftware.ssboneblock.commands.commands;
 import com.bgsoftware.ssboneblock.OneBlockModule;
 import com.bgsoftware.ssboneblock.commands.ICommand;
 import com.bgsoftware.ssboneblock.lang.Message;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
 import java.util.ArrayList;

--- a/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdReload.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdReload.java
@@ -2,7 +2,7 @@ package com.bgsoftware.ssboneblock.commands.commands;
 
 import com.bgsoftware.ssboneblock.OneBlockModule;
 import com.bgsoftware.ssboneblock.commands.ICommand;
-import com.bgsoftware.superiorskyblock.api.SuperiorSkyblock;
+import com.bgsoftware.ssboneblock.lang.Message;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
@@ -17,8 +17,8 @@ public final class CmdReload implements ICommand {
     }
 
     @Override
-    public String getUsage() {
-        return "oneblock reload";
+    public String getUsage(java.util.Locale locale) {
+        return "reload";
     }
 
     @Override
@@ -27,8 +27,8 @@ public final class CmdReload implements ICommand {
     }
 
     @Override
-    public String getDescription() {
-        return "Reload all settings of the plugin.";
+    public String getDescription(java.util.Locale locale) {
+        return Message.COMMAND_DESCRIPTION_RELOAD.getMessage(locale);
     }
 
     @Override
@@ -47,8 +47,7 @@ public final class CmdReload implements ICommand {
         module.getPlugin().getServer().getScheduler().runTaskAsynchronously(module.getPlugin(), () -> {
             module.getPhasesHandler().getDataStore().save();
             module.onReload(module.getPlugin());
-            sender.sendMessage(ChatColor.YELLOW + "Successfully loaded all files (Took " +
-                    (System.currentTimeMillis() - startTime) + "ms)!");
+            Message.RELOAD_FILES.send(sender, (System.currentTimeMillis() - startTime));
         });
     }
 

--- a/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdSave.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdSave.java
@@ -3,7 +3,6 @@ package com.bgsoftware.ssboneblock.commands.commands;
 import com.bgsoftware.ssboneblock.OneBlockModule;
 import com.bgsoftware.ssboneblock.commands.ICommand;
 import com.bgsoftware.ssboneblock.lang.Message;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
 import java.util.ArrayList;

--- a/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdSave.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdSave.java
@@ -2,6 +2,7 @@ package com.bgsoftware.ssboneblock.commands.commands;
 
 import com.bgsoftware.ssboneblock.OneBlockModule;
 import com.bgsoftware.ssboneblock.commands.ICommand;
+import com.bgsoftware.ssboneblock.lang.Message;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
@@ -16,8 +17,8 @@ public final class CmdSave implements ICommand {
     }
 
     @Override
-    public String getUsage() {
-        return "oneblock save";
+    public String getUsage(java.util.Locale locale) {
+        return "save";
     }
 
     @Override
@@ -26,8 +27,8 @@ public final class CmdSave implements ICommand {
     }
 
     @Override
-    public String getDescription() {
-        return "Save all data to disk.";
+    public String getDescription(java.util.Locale locale) {
+        return Message.COMMAND_DESCRIPTION_SAVE.getMessage(locale);
     }
 
     @Override
@@ -45,8 +46,7 @@ public final class CmdSave implements ICommand {
         long startTime = System.currentTimeMillis();
         module.getPlugin().getServer().getScheduler().runTaskAsynchronously(module.getPlugin(), () -> {
             module.getPhasesHandler().getDataStore().save();
-            sender.sendMessage(ChatColor.YELLOW + "Successfully saved all data (Took " +
-                    (System.currentTimeMillis() - startTime) + "ms)!");
+            Message.SAVE_DATA.send(sender, (System.currentTimeMillis() - startTime));
         });
     }
 

--- a/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdSetPhase.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdSetPhase.java
@@ -21,8 +21,11 @@ public final class CmdSetPhase implements ICommand {
     }
 
     @Override
-    public String getUsage() {
-        return "oneblock setphase <player-name/island-name> <phase-level>";
+    public String getUsage(java.util.Locale locale) {
+        return "setphase <" +
+                Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
+                Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "> <" +
+                Message.COMMAND_ARGUMENT_PHASE_LEVEL.getMessage(locale) + ">";
     }
 
     @Override
@@ -31,8 +34,8 @@ public final class CmdSetPhase implements ICommand {
     }
 
     @Override
-    public String getDescription() {
-        return "Set the phase for a specific player.";
+    public String getDescription(java.util.Locale locale) {
+        return Message.COMMAND_DESCRIPTION_SET_PHASE.getMessage(locale);
     }
 
     @Override
@@ -55,7 +58,7 @@ public final class CmdSetPhase implements ICommand {
             return;
         }
 
-        if(!module.getPhasesHandler().canHaveOneBlock(island)) {
+        if (!module.getPhasesHandler().canHaveOneBlock(island)) {
             Message.ISLAND_MISSING_BLOCK.send(sender);
             return;
         }

--- a/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdSetPhaseBlock.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/commands/commands/CmdSetPhaseBlock.java
@@ -21,8 +21,11 @@ public final class CmdSetPhaseBlock implements ICommand {
     }
 
     @Override
-    public String getUsage() {
-        return "oneblock setphaseblock <player-name/island-name> <phase-block>";
+    public String getUsage(java.util.Locale locale) {
+        return "setphaseblock <" +
+                Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
+                Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "> <" +
+                Message.COMMAND_ARGUMENT_PHASE_BLOCK.getMessage(locale) + ">";
     }
 
     @Override
@@ -31,8 +34,8 @@ public final class CmdSetPhaseBlock implements ICommand {
     }
 
     @Override
-    public String getDescription() {
-        return "Set the phase-block for a specific player.";
+    public String getDescription(java.util.Locale locale) {
+        return Message.COMMAND_DESCRIPTION_SET_PHASE_BLOCK.getMessage(locale);
     }
 
     @Override
@@ -50,29 +53,28 @@ public final class CmdSetPhaseBlock implements ICommand {
         SuperiorPlayer targetPlayer = SuperiorSkyblockAPI.getPlayer(args[1]);
         Island island = targetPlayer == null ? SuperiorSkyblockAPI.getGrid().getIsland(args[1]) : targetPlayer.getIsland();
 
-        if(island == null){
+        if (island == null) {
             Message.INVALID_ISLAND.send(sender, args[1]);
             return;
         }
 
-        if(!module.getPhasesHandler().canHaveOneBlock(island)) {
+        if (!module.getPhasesHandler().canHaveOneBlock(island)) {
             Message.ISLAND_MISSING_BLOCK.send(sender);
             return;
         }
 
         int phaseBlock;
 
-        try{
+        try {
             phaseBlock = Integer.parseInt(args[2]);
-        }catch(Exception ex){
+        } catch (Exception ex) {
             Message.INVALID_NUMBER.send(sender, args[2]);
             return;
         }
 
-        if(phaseBlock <= 0 || !module.getPhasesHandler().setPhaseBlock(island, phaseBlock - 1, island.getOwner())){
+        if (phaseBlock <= 0 || !module.getPhasesHandler().setPhaseBlock(island, phaseBlock - 1, island.getOwner())) {
             Message.SET_PHASE_BLOCK_FAILURE.send(sender, phaseBlock);
-        }
-        else{
+        } else {
             Message.SET_PHASE_BLOCK_SUCCESS.send(sender, args[1], phaseBlock);
         }
     }
@@ -81,7 +83,7 @@ public final class CmdSetPhaseBlock implements ICommand {
     public List<String> tabComplete(OneBlockModule module, CommandSender sender, String[] args) {
         List<String> list = new ArrayList<>();
 
-        if(args.length == 2) {
+        if (args.length == 2) {
             for (Player player : Bukkit.getOnlinePlayers()) {
                 SuperiorPlayer onlinePlayer = SuperiorSkyblockAPI.getPlayer(player);
                 Island playerIsland = onlinePlayer.getIsland();

--- a/src/main/java/com/bgsoftware/ssboneblock/commands/commands/SSBCheckCmd.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/commands/commands/SSBCheckCmd.java
@@ -1,13 +1,13 @@
 package com.bgsoftware.ssboneblock.commands.commands;
 
 import com.bgsoftware.ssboneblock.OneBlockModule;
+import com.bgsoftware.ssboneblock.lang.Message;
 import com.bgsoftware.superiorskyblock.api.SuperiorSkyblock;
 import com.bgsoftware.superiorskyblock.api.commands.SuperiorCommand;
 import org.bukkit.command.CommandSender;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 
 public class SSBCheckCmd implements SuperiorCommand {
 
@@ -24,13 +24,15 @@ public class SSBCheckCmd implements SuperiorCommand {
     }
 
     @Override
-    public String getUsage(Locale locale) {
-        return "check [player-name/island-name]";
+    public String getUsage(java.util.Locale locale) {
+        return "oneblock [" +
+                Message.COMMAND_ARGUMENT_PLAYER_NAME.getMessage(locale) + "/" +
+                Message.COMMAND_ARGUMENT_ISLAND_NAME.getMessage(locale) + "]";
     }
 
     @Override
-    public String getDescription(Locale locale) {
-        return "Check one-block progress of a player.";
+    public String getDescription(java.util.Locale locale) {
+        return Message.COMMAND_DESCRIPTION_CHECK.getMessage(locale);
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/ssboneblock/lang/Message.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/lang/Message.java
@@ -19,6 +19,15 @@ import java.util.Objects;
 
 public enum Message {
 
+    COMMAND_ARGUMENT_ISLAND_NAME,
+    COMMAND_ARGUMENT_PHASE_BLOCK,
+    COMMAND_ARGUMENT_PHASE_LEVEL,
+    COMMAND_ARGUMENT_PLAYER_NAME,
+    COMMAND_DESCRIPTION_CHECK,
+    COMMAND_DESCRIPTION_RELOAD,
+    COMMAND_DESCRIPTION_SAVE,
+    COMMAND_DESCRIPTION_SET_PHASE,
+    COMMAND_DESCRIPTION_SET_PHASE_BLOCK,
     COMMAND_USAGE,
     HELP_COMMAND_HEADER,
     HELP_COMMAND_LINE,
@@ -30,6 +39,8 @@ public enum Message {
     NO_PERMISSION,
     PHASE_PROGRESS,
     PHASE_STATUS,
+    RELOAD_FILES,
+    SAVE_DATA,
     SET_PHASE_BLOCK_FAILURE,
     SET_PHASE_BLOCK_SUCCESS,
     SET_PHASE_FAILURE,
@@ -39,6 +50,10 @@ public enum Message {
     private static final IMessageComponent EMPTY_COMPONENT = MESSAGES_SERVICE.newBuilder().build();
 
     private final Map<Locale, IMessageComponent> messages = new HashMap<>();
+
+    public String getMessage(java.util.Locale locale) {
+        return messages.getOrDefault(locale, EMPTY_COMPONENT).getMessage();
+    }
 
     public void send(@Nullable SuperiorPlayer superiorPlayer, Object... objects) {
         if (superiorPlayer != null)

--- a/src/main/resources/lang/de-DE.yml
+++ b/src/main/resources/lang/de-DE.yml
@@ -5,14 +5,19 @@
 ##                                                  ##
 ######################################################
 
-COMMAND_USAGE: '&cUsage: {0}'
-HELP_COMMAND_HEADER: |
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
-  &8 &8
-HELP_COMMAND_LINE: '&7- &e/{0} &8- &f{1}'
-HELP_COMMAND_FOOTER: |
-  &8 &8
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
+COMMAND_ARGUMENT_ISLAND_NAME: island-name
+COMMAND_ARGUMENT_PHASE_BLOCK: phase-block
+COMMAND_ARGUMENT_PHASE_LEVEL: phase-level
+COMMAND_ARGUMENT_PLAYER_NAME: player-name
+COMMAND_DESCRIPTION_CHECK: 'Check progress of a player.'
+COMMAND_DESCRIPTION_RELOAD: 'Reload all settings of the plugin.'
+COMMAND_DESCRIPTION_SAVE: 'Save all data to disk.'
+COMMAND_DESCRIPTION_SET_PHASE: 'Set the phase for a specific player.'
+COMMAND_DESCRIPTION_SET_PHASE_BLOCK: 'Set the phase-block for a specific player.'
+COMMAND_USAGE: '&cUsage: /{0}'
+HELP_COMMAND_HEADER: '&e&lSSBOneBlock &7Commands List:'
+HELP_COMMAND_LINE: '&e/{0} &f- &7{1}'
+HELP_COMMAND_FOOTER: '&e&lSSBOneBlock &7Developed by Ome_R'
 INVALID_ISLAND: '&c&lError | &7Cannot find the island of the player {0}.'
 INVALID_NUMBER: '&c&lError | &7Invalid number {0}.'
 ISLAND_MISSING_BLOCK: '&c&lError | &7This island cannot have a one-block.'
@@ -20,7 +25,9 @@ NO_MORE_PHASES: '&e&lIsland | &7You are at the last phase.'
 NO_PERMISSION: '&fUnknown command. Type \"/help\" for help.'
 PHASE_PROGRESS:
   action-bar:
-    text: '&6Progress: {0}%'
+    text: '&6Progress: {0}% &7({1}/{2})'
+RELOAD_FILES: '&e&lIsland | &7Successfully reloaded all files in {0}ms.'
+SAVE_DATA: '&e&lIsland | &7Successfully saved all data in {0}ms.'
 SET_PHASE_BLOCK_FAILURE: '&c&lError | &7You cannot change the phase-block to {0}.'
 SET_PHASE_BLOCK_SUCCESS: '&e&lIsland | &7Successfully changed the phase block for {0} to {1}.'
 SET_PHASE_FAILURE: '&c&lError | &7You cannot change the phase-level to {0}.'

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -5,14 +5,19 @@
 ##                                                  ##
 ######################################################
 
-COMMAND_USAGE: '&cUsage: {0}'
-HELP_COMMAND_HEADER: |
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
-  &8 &8
-HELP_COMMAND_LINE: '&7- &e/{0} &8- &f{1}'
-HELP_COMMAND_FOOTER: |
-  &8 &8
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
+COMMAND_ARGUMENT_ISLAND_NAME: island-name
+COMMAND_ARGUMENT_PHASE_BLOCK: phase-block
+COMMAND_ARGUMENT_PHASE_LEVEL: phase-level
+COMMAND_ARGUMENT_PLAYER_NAME: player-name
+COMMAND_DESCRIPTION_CHECK: 'Check progress of a player.'
+COMMAND_DESCRIPTION_RELOAD: 'Reload all settings of the plugin.'
+COMMAND_DESCRIPTION_SAVE: 'Save all data to disk.'
+COMMAND_DESCRIPTION_SET_PHASE: 'Set the phase for a specific player.'
+COMMAND_DESCRIPTION_SET_PHASE_BLOCK: 'Set the phase-block for a specific player.'
+COMMAND_USAGE: '&cUsage: /{0}'
+HELP_COMMAND_HEADER: '&e&lSSBOneBlock &7Commands List:'
+HELP_COMMAND_LINE: '&e/{0} &f- &7{1}'
+HELP_COMMAND_FOOTER: '&e&lSSBOneBlock &7Developed by Ome_R'
 INVALID_ISLAND: '&c&lError | &7Cannot find the island of the player {0}.'
 INVALID_NUMBER: '&c&lError | &7Invalid number {0}.'
 ISLAND_MISSING_BLOCK: '&c&lError | &7This island cannot have a one-block.'
@@ -20,7 +25,9 @@ NO_MORE_PHASES: '&e&lIsland | &7You are at the last phase.'
 NO_PERMISSION: '&fUnknown command. Type \"/help\" for help.'
 PHASE_PROGRESS:
   action-bar:
-    text: '&6Progress: {0}%'
+    text: '&6Progress: {0}% &7({1}/{2})'
+RELOAD_FILES: '&e&lIsland | &7Successfully reloaded all files in {0}ms.'
+SAVE_DATA: '&e&lIsland | &7Successfully saved all data in {0}ms.'
 SET_PHASE_BLOCK_FAILURE: '&c&lError | &7You cannot change the phase-block to {0}.'
 SET_PHASE_BLOCK_SUCCESS: '&e&lIsland | &7Successfully changed the phase block for {0} to {1}.'
 SET_PHASE_FAILURE: '&c&lError | &7You cannot change the phase-level to {0}.'

--- a/src/main/resources/lang/es-ES.yml
+++ b/src/main/resources/lang/es-ES.yml
@@ -5,14 +5,19 @@
 ##                                                  ##
 ######################################################
 
-COMMAND_USAGE: '&cUsage: {0}'
-HELP_COMMAND_HEADER: |
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
-  &8 &8
-HELP_COMMAND_LINE: '&7- &e/{0} &8- &f{1}'
-HELP_COMMAND_FOOTER: |
-  &8 &8
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
+COMMAND_ARGUMENT_ISLAND_NAME: island-name
+COMMAND_ARGUMENT_PHASE_BLOCK: phase-block
+COMMAND_ARGUMENT_PHASE_LEVEL: phase-level
+COMMAND_ARGUMENT_PLAYER_NAME: player-name
+COMMAND_DESCRIPTION_CHECK: 'Check progress of a player.'
+COMMAND_DESCRIPTION_RELOAD: 'Reload all settings of the plugin.'
+COMMAND_DESCRIPTION_SAVE: 'Save all data to disk.'
+COMMAND_DESCRIPTION_SET_PHASE: 'Set the phase for a specific player.'
+COMMAND_DESCRIPTION_SET_PHASE_BLOCK: 'Set the phase-block for a specific player.'
+COMMAND_USAGE: '&cUsage: /{0}'
+HELP_COMMAND_HEADER: '&e&lSSBOneBlock &7Commands List:'
+HELP_COMMAND_LINE: '&e/{0} &f- &7{1}'
+HELP_COMMAND_FOOTER: '&e&lSSBOneBlock &7Developed by Ome_R'
 INVALID_ISLAND: '&c&lError | &7Cannot find the island of the player {0}.'
 INVALID_NUMBER: '&c&lError | &7Invalid number {0}.'
 ISLAND_MISSING_BLOCK: '&c&lError | &7This island cannot have a one-block.'
@@ -20,7 +25,9 @@ NO_MORE_PHASES: '&e&lIsland | &7You are at the last phase.'
 NO_PERMISSION: '&fUnknown command. Type \"/help\" for help.'
 PHASE_PROGRESS:
   action-bar:
-    text: '&6Progress: {0}%'
+    text: '&6Progress: {0}% &7({1}/{2})'
+RELOAD_FILES: '&e&lIsland | &7Successfully reloaded all files in {0}ms.'
+SAVE_DATA: '&e&lIsland | &7Successfully saved all data in {0}ms.'
 SET_PHASE_BLOCK_FAILURE: '&c&lError | &7You cannot change the phase-block to {0}.'
 SET_PHASE_BLOCK_SUCCESS: '&e&lIsland | &7Successfully changed the phase block for {0} to {1}.'
 SET_PHASE_FAILURE: '&c&lError | &7You cannot change the phase-level to {0}.'

--- a/src/main/resources/lang/fr-FR.yml
+++ b/src/main/resources/lang/fr-FR.yml
@@ -5,14 +5,19 @@
 ##                                                  ##
 ######################################################
 
-COMMAND_USAGE: '&cUsage: {0}'
-HELP_COMMAND_HEADER: |
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
-  &8 &8
-HELP_COMMAND_LINE: '&7- &e/{0} &8- &f{1}'
-HELP_COMMAND_FOOTER: |
-  &8 &8
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
+COMMAND_ARGUMENT_ISLAND_NAME: island-name
+COMMAND_ARGUMENT_PHASE_BLOCK: phase-block
+COMMAND_ARGUMENT_PHASE_LEVEL: phase-level
+COMMAND_ARGUMENT_PLAYER_NAME: player-name
+COMMAND_DESCRIPTION_CHECK: 'Check progress of a player.'
+COMMAND_DESCRIPTION_RELOAD: 'Reload all settings of the plugin.'
+COMMAND_DESCRIPTION_SAVE: 'Save all data to disk.'
+COMMAND_DESCRIPTION_SET_PHASE: 'Set the phase for a specific player.'
+COMMAND_DESCRIPTION_SET_PHASE_BLOCK: 'Set the phase-block for a specific player.'
+COMMAND_USAGE: '&cUsage: /{0}'
+HELP_COMMAND_HEADER: '&e&lSSBOneBlock &7Commands List:'
+HELP_COMMAND_LINE: '&e/{0} &f- &7{1}'
+HELP_COMMAND_FOOTER: '&e&lSSBOneBlock &7Developed by Ome_R'
 INVALID_ISLAND: '&c&lError | &7Cannot find the island of the player {0}.'
 INVALID_NUMBER: '&c&lError | &7Invalid number {0}.'
 ISLAND_MISSING_BLOCK: '&c&lError | &7This island cannot have a one-block.'
@@ -20,7 +25,9 @@ NO_MORE_PHASES: '&e&lIsland | &7You are at the last phase.'
 NO_PERMISSION: '&fUnknown command. Type \"/help\" for help.'
 PHASE_PROGRESS:
   action-bar:
-    text: '&6Progress: {0}%'
+    text: '&6Progress: {0}% &7({1}/{2})'
+RELOAD_FILES: '&e&lIsland | &7Successfully reloaded all files in {0}ms.'
+SAVE_DATA: '&e&lIsland | &7Successfully saved all data in {0}ms.'
 SET_PHASE_BLOCK_FAILURE: '&c&lError | &7You cannot change the phase-block to {0}.'
 SET_PHASE_BLOCK_SUCCESS: '&e&lIsland | &7Successfully changed the phase block for {0} to {1}.'
 SET_PHASE_FAILURE: '&c&lError | &7You cannot change the phase-level to {0}.'

--- a/src/main/resources/lang/it-IT.yml
+++ b/src/main/resources/lang/it-IT.yml
@@ -5,14 +5,19 @@
 ##                                                  ##
 ######################################################
 
-COMMAND_USAGE: '&cUsage: {0}'
-HELP_COMMAND_HEADER: |
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
-  &8 &8
-HELP_COMMAND_LINE: '&7- &e/{0} &8- &f{1}'
-HELP_COMMAND_FOOTER: |
-  &8 &8
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
+COMMAND_ARGUMENT_ISLAND_NAME: island-name
+COMMAND_ARGUMENT_PHASE_BLOCK: phase-block
+COMMAND_ARGUMENT_PHASE_LEVEL: phase-level
+COMMAND_ARGUMENT_PLAYER_NAME: player-name
+COMMAND_DESCRIPTION_CHECK: 'Check progress of a player.'
+COMMAND_DESCRIPTION_RELOAD: 'Reload all settings of the plugin.'
+COMMAND_DESCRIPTION_SAVE: 'Save all data to disk.'
+COMMAND_DESCRIPTION_SET_PHASE: 'Set the phase for a specific player.'
+COMMAND_DESCRIPTION_SET_PHASE_BLOCK: 'Set the phase-block for a specific player.'
+COMMAND_USAGE: '&cUsage: /{0}'
+HELP_COMMAND_HEADER: '&e&lSSBOneBlock &7Commands List:'
+HELP_COMMAND_LINE: '&e/{0} &f- &7{1}'
+HELP_COMMAND_FOOTER: '&e&lSSBOneBlock &7Developed by Ome_R'
 INVALID_ISLAND: '&c&lError | &7Cannot find the island of the player {0}.'
 INVALID_NUMBER: '&c&lError | &7Invalid number {0}.'
 ISLAND_MISSING_BLOCK: '&c&lError | &7This island cannot have a one-block.'
@@ -20,7 +25,9 @@ NO_MORE_PHASES: '&e&lIsland | &7You are at the last phase.'
 NO_PERMISSION: '&fUnknown command. Type \"/help\" for help.'
 PHASE_PROGRESS:
   action-bar:
-    text: '&6Progress: {0}%'
+    text: '&6Progress: {0}% &7({1}/{2})'
+RELOAD_FILES: '&e&lIsland | &7Successfully reloaded all files in {0}ms.'
+SAVE_DATA: '&e&lIsland | &7Successfully saved all data in {0}ms.'
 SET_PHASE_BLOCK_FAILURE: '&c&lError | &7You cannot change the phase-block to {0}.'
 SET_PHASE_BLOCK_SUCCESS: '&e&lIsland | &7Successfully changed the phase block for {0} to {1}.'
 SET_PHASE_FAILURE: '&c&lError | &7You cannot change the phase-level to {0}.'

--- a/src/main/resources/lang/iw-IL.yml
+++ b/src/main/resources/lang/iw-IL.yml
@@ -5,14 +5,19 @@
 ##                                                  ##
 ######################################################
 
-COMMAND_USAGE: '&cUsage: {0}'
-HELP_COMMAND_HEADER: |
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
-  &8 &8
-HELP_COMMAND_LINE: '&7- &e/{0} &8- &f{1}'
-HELP_COMMAND_FOOTER: |
-  &8 &8
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
+COMMAND_ARGUMENT_ISLAND_NAME: island-name
+COMMAND_ARGUMENT_PHASE_BLOCK: phase-block
+COMMAND_ARGUMENT_PHASE_LEVEL: phase-level
+COMMAND_ARGUMENT_PLAYER_NAME: player-name
+COMMAND_DESCRIPTION_CHECK: 'Check progress of a player.'
+COMMAND_DESCRIPTION_RELOAD: 'Reload all settings of the plugin.'
+COMMAND_DESCRIPTION_SAVE: 'Save all data to disk.'
+COMMAND_DESCRIPTION_SET_PHASE: 'Set the phase for a specific player.'
+COMMAND_DESCRIPTION_SET_PHASE_BLOCK: 'Set the phase-block for a specific player.'
+COMMAND_USAGE: '&cUsage: /{0}'
+HELP_COMMAND_HEADER: '&e&lSSBOneBlock &7Commands List:'
+HELP_COMMAND_LINE: '&e/{0} &f- &7{1}'
+HELP_COMMAND_FOOTER: '&e&lSSBOneBlock &7Developed by Ome_R'
 INVALID_ISLAND: '&c&lError | &7Cannot find the island of the player {0}.'
 INVALID_NUMBER: '&c&lError | &7Invalid number {0}.'
 ISLAND_MISSING_BLOCK: '&c&lError | &7This island cannot have a one-block.'
@@ -20,7 +25,9 @@ NO_MORE_PHASES: '&e&lIsland | &7You are at the last phase.'
 NO_PERMISSION: '&fUnknown command. Type \"/help\" for help.'
 PHASE_PROGRESS:
   action-bar:
-    text: '&6Progress: {0}%'
+    text: '&6Progress: {0}% &7({1}/{2})'
+RELOAD_FILES: '&e&lIsland | &7Successfully reloaded all files in {0}ms.'
+SAVE_DATA: '&e&lIsland | &7Successfully saved all data in {0}ms.'
 SET_PHASE_BLOCK_FAILURE: '&c&lError | &7You cannot change the phase-block to {0}.'
 SET_PHASE_BLOCK_SUCCESS: '&e&lIsland | &7Successfully changed the phase block for {0} to {1}.'
 SET_PHASE_FAILURE: '&c&lError | &7You cannot change the phase-level to {0}.'

--- a/src/main/resources/lang/pl-PL.yml
+++ b/src/main/resources/lang/pl-PL.yml
@@ -5,26 +5,33 @@
 ##                                                  ##
 ######################################################
 
-COMMAND_USAGE: '&cUsage: {0}'
-HELP_COMMAND_HEADER: |
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
-  &8 &8
-HELP_COMMAND_LINE: '&7- &e/{0} &8- &f{1}'
-HELP_COMMAND_FOOTER: |
-  &8 &8
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
-INVALID_ISLAND: '&c&lError | &7Cannot find the island of the player {0}.'
-INVALID_NUMBER: '&c&lError | &7Invalid number {0}.'
-ISLAND_MISSING_BLOCK: '&c&lError | &7This island cannot have a one-block.'
-NO_MORE_PHASES: '&e&lIsland | &7You are at the last phase.'
-NO_PERMISSION: '&fUnknown command. Type \"/help\" for help.'
+COMMAND_ARGUMENT_ISLAND_NAME: nazwa-wyspy
+COMMAND_ARGUMENT_PHASE_BLOCK: blok-fazy
+COMMAND_ARGUMENT_PHASE_LEVEL: poziom-fazy
+COMMAND_ARGUMENT_PLAYER_NAME: nazwa-gracza
+COMMAND_DESCRIPTION_CHECK: 'Sprawdź postęp gracza.'
+COMMAND_DESCRIPTION_RELOAD: 'Przeładuj wszystkie ustawienia pluginu.'
+COMMAND_DESCRIPTION_SAVE: 'Zapisz wszystkie dane na dysku.'
+COMMAND_DESCRIPTION_SET_PHASE: 'Ustaw fazę dla konkretnego gracza.'
+COMMAND_DESCRIPTION_SET_PHASE_BLOCK: 'Ustaw blok fazy dla konkretnego gracza.'
+COMMAND_USAGE: '&cUżycie: /{0}'
+HELP_COMMAND_HEADER: '&e&lSSBOneBlock &7Lista poleceń:'
+HELP_COMMAND_LINE: '&e/{0} &f- &7{1}'
+HELP_COMMAND_FOOTER: '&e&lSSBOneBlock &7Opracowane przez Ome_R'
+INVALID_ISLAND: '&c&lBłąd | &7Nie można znaleźć wyspy gracza {0}.'
+INVALID_NUMBER: '&c&lBłąd | &7Nieprawidłowa liczba {0}.'
+ISLAND_MISSING_BLOCK: '&c&lBłąd | &7Ta wyspa nie może mieć one blocka.'
+NO_MORE_PHASES: '&e&lWyspa | &7Jesteś na ostatniej fazie.'
+NO_PERMISSION: '&fNieznane polecenie. Wpisz \"/help\", aby uzyskać pomoc.'
 PHASE_PROGRESS:
   action-bar:
-    text: '&6Progress: {0}%'
-SET_PHASE_BLOCK_FAILURE: '&c&lError | &7You cannot change the phase-block to {0}.'
-SET_PHASE_BLOCK_SUCCESS: '&e&lIsland | &7Successfully changed the phase block for {0} to {1}.'
-SET_PHASE_FAILURE: '&c&lError | &7You cannot change the phase-level to {0}.'
-SET_PHASE_SUCCESS: '&e&lIsland | &7Successfully changed the phase level for {0} to {1}.'
+    text: '&6Postęp: {0}% &7({1}/{2})'
+RELOAD_FILES: '&e&lIsland | &7Pomyślnie przeładowano wszystkie pliki w czasie {0} ms.'
+SAVE_DATA: '&e&lIsland | &7Pomyślnie zapisano wszystkie dane w czasie {0} ms.'
+SET_PHASE_BLOCK_FAILURE: '&c&lBłąd | &7Nie możesz zmienić bloku fazy na {0}.'
+SET_PHASE_BLOCK_SUCCESS: '&e&lWyspa | &7Pomyślnie zmieniono blok fazy dla {0} na {1}.'
+SET_PHASE_FAILURE: '&c&lBłąd | &7Nie możesz zmienić poziomu fazy na {0}.'
+SET_PHASE_SUCCESS: '&e&lWyspa | &7Pomyślnie zmieniono poziom fazy dla {0} na {1}.'
 PHASE_STATUS: |
-  &e&lPhase | &7Phase Level: {0}
-  &e&lPhase | &7Phase Block: {1}
+  &e&lFaza | &7Poziom fazy: {0}
+  &e&lFaza | &7Blok fazy: {1}

--- a/src/main/resources/lang/ru-RU.yml
+++ b/src/main/resources/lang/ru-RU.yml
@@ -5,14 +5,19 @@
 ##                                                  ##
 ######################################################
 
-COMMAND_USAGE: '&cИспользование: {0}'
-HELP_COMMAND_HEADER: |
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
-  &8 &8
-HELP_COMMAND_LINE: '&7- &e/{0} &8- &f{1}'
-HELP_COMMAND_FOOTER: |
-  &8 &8
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
+COMMAND_ARGUMENT_ISLAND_NAME: island-name
+COMMAND_ARGUMENT_PHASE_BLOCK: phase-block
+COMMAND_ARGUMENT_PHASE_LEVEL: phase-level
+COMMAND_ARGUMENT_PLAYER_NAME: player-name
+COMMAND_DESCRIPTION_CHECK: 'Check progress of a player.'
+COMMAND_DESCRIPTION_RELOAD: 'Reload all settings of the plugin.'
+COMMAND_DESCRIPTION_SAVE: 'Save all data to disk.'
+COMMAND_DESCRIPTION_SET_PHASE: 'Set the phase for a specific player.'
+COMMAND_DESCRIPTION_SET_PHASE_BLOCK: 'Set the phase-block for a specific player.'
+COMMAND_USAGE: '&cИспользование: /{0}'
+HELP_COMMAND_HEADER: '&e&lSSBOneBlock &7Commands List:'
+HELP_COMMAND_LINE: '&e/{0} &f- &7{1}'
+HELP_COMMAND_FOOTER: '&e&lSSBOneBlock &7Developed by Ome_R'
 INVALID_ISLAND: '&c&lОшибка | &7Невозможно найти остров игрока {0}.'
 INVALID_NUMBER: '&c&lОшибка | &7Недопустимый номер {0}.'
 ISLAND_MISSING_BLOCK: '&c&lОшибка | &7На этом острове не может быть одного блока.'
@@ -20,7 +25,9 @@ NO_MORE_PHASES: '&e&lОстров | &7Вы на последней фазе.'
 NO_PERMISSION: '&fНеизвестная команда. Введите \"/help\" для справки.'
 PHASE_PROGRESS:
   action-bar:
-    text: '&6Прогресс: {0}%'
+    text: '&6Прогресс: {0}% &7({1}/{2})'
+RELOAD_FILES: '&e&lIsland | &7Successfully reloaded all files in {0}ms.'
+SAVE_DATA: '&e&lIsland | &7Successfully saved all data in {0}ms.'
 SET_PHASE_BLOCK_FAILURE: '&c&lОшибка | &7Вы не можете изменить блок фазы на {0}.'
 SET_PHASE_BLOCK_SUCCESS: '&e&lОстров | &7Успешно изменен блок фазы для {0} на {1}.'
 SET_PHASE_FAILURE: '&c&lОшибка | &7Вы не можете изменить уровень фазы на {0}.'

--- a/src/main/resources/lang/vi-VN.yml
+++ b/src/main/resources/lang/vi-VN.yml
@@ -5,14 +5,19 @@
 ##                                                  ##
 ######################################################
 
-COMMAND_USAGE: '&cUsage: {0}'
-HELP_COMMAND_HEADER: |
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
-  &8 &8
-HELP_COMMAND_LINE: '&7- &e/{0} &8- &f{1}'
-HELP_COMMAND_FOOTER: |
-  &8 &8
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
+COMMAND_ARGUMENT_ISLAND_NAME: island-name
+COMMAND_ARGUMENT_PHASE_BLOCK: phase-block
+COMMAND_ARGUMENT_PHASE_LEVEL: phase-level
+COMMAND_ARGUMENT_PLAYER_NAME: player-name
+COMMAND_DESCRIPTION_CHECK: 'Check progress of a player.'
+COMMAND_DESCRIPTION_RELOAD: 'Reload all settings of the plugin.'
+COMMAND_DESCRIPTION_SAVE: 'Save all data to disk.'
+COMMAND_DESCRIPTION_SET_PHASE: 'Set the phase for a specific player.'
+COMMAND_DESCRIPTION_SET_PHASE_BLOCK: 'Set the phase-block for a specific player.'
+COMMAND_USAGE: '&cUsage: /{0}'
+HELP_COMMAND_HEADER: '&e&lSSBOneBlock &7Commands List:'
+HELP_COMMAND_LINE: '&e/{0} &f- &7{1}'
+HELP_COMMAND_FOOTER: '&e&lSSBOneBlock &7Developed by Ome_R'
 INVALID_ISLAND: '&c&lError | &7Cannot find the island of the player {0}.'
 INVALID_NUMBER: '&c&lError | &7Invalid number {0}.'
 ISLAND_MISSING_BLOCK: '&c&lError | &7This island cannot have a one-block.'
@@ -20,7 +25,9 @@ NO_MORE_PHASES: '&e&lIsland | &7You are at the last phase.'
 NO_PERMISSION: '&fUnknown command. Type \"/help\" for help.'
 PHASE_PROGRESS:
   action-bar:
-    text: '&6Progress: {0}%'
+    text: '&6Progress: {0}% &7({1}/{2})'
+RELOAD_FILES: '&e&lIsland | &7Successfully reloaded all files in {0}ms.'
+SAVE_DATA: '&e&lIsland | &7Successfully saved all data in {0}ms.'
 SET_PHASE_BLOCK_FAILURE: '&c&lError | &7You cannot change the phase-block to {0}.'
 SET_PHASE_BLOCK_SUCCESS: '&e&lIsland | &7Successfully changed the phase block for {0} to {1}.'
 SET_PHASE_FAILURE: '&c&lError | &7You cannot change the phase-level to {0}.'

--- a/src/main/resources/lang/zh-CN.yml
+++ b/src/main/resources/lang/zh-CN.yml
@@ -5,14 +5,19 @@
 ##                                                  ##
 ######################################################
 
-COMMAND_USAGE: '&c命令用法: {0}'
-HELP_COMMAND_HEADER: |
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
-  &8 &8
-HELP_COMMAND_LINE: '&7- &e/{0} &8- &f{1}'
-HELP_COMMAND_FOOTER: |
-  &8 &8
-  &8&m---------------&e&l SSB - OneBlock &8&m---------------
+COMMAND_ARGUMENT_ISLAND_NAME: island-name
+COMMAND_ARGUMENT_PHASE_BLOCK: phase-block
+COMMAND_ARGUMENT_PHASE_LEVEL: phase-level
+COMMAND_ARGUMENT_PLAYER_NAME: player-name
+COMMAND_DESCRIPTION_CHECK: 'Check progress of a player.'
+COMMAND_DESCRIPTION_RELOAD: 'Reload all settings of the plugin.'
+COMMAND_DESCRIPTION_SAVE: 'Save all data to disk.'
+COMMAND_DESCRIPTION_SET_PHASE: 'Set the phase for a specific player.'
+COMMAND_DESCRIPTION_SET_PHASE_BLOCK: 'Set the phase-block for a specific player.'
+COMMAND_USAGE: '&c命令用法: /{0}'
+HELP_COMMAND_HEADER: '&e&lSSBOneBlock &7Commands List:'
+HELP_COMMAND_LINE: '&e/{0} &f- &7{1}'
+HELP_COMMAND_FOOTER: '&e&lSSBOneBlock &7Developed by Ome_R'
 INVALID_ISLAND: '&c&l错误 | &7找不到玩家 {0} 的岛屿.'
 INVALID_NUMBER: '&c&l错误 | &7无效数字 {0}.'
 ISLAND_MISSING_BLOCK: '&c&l错误 | &7该岛屿不可设置单方块空岛.'
@@ -20,7 +25,9 @@ NO_MORE_PHASES: '&e&l岛屿 | &7你已到达最终阶段.'
 NO_PERMISSION: '&f未知命令. 请输入 \"/help\" 获取帮助.'
 PHASE_PROGRESS:
   action-bar:
-    text: '&6进度: {0}%'
+    text: '&6进度: {0}% &7({1}/{2})'
+RELOAD_FILES: '&e&lIsland | &7Successfully reloaded all files in {0}ms.'
+SAVE_DATA: '&e&lIsland | &7Successfully saved all data in {0}ms.'
 SET_PHASE_BLOCK_FAILURE: '&c&l错误 | &7你不能将阶段方块设置为 {0}.'
 SET_PHASE_BLOCK_SUCCESS: '&e&l岛屿 | &7成功将阶段方块从 {0} 修改为 {1}.'
 SET_PHASE_FAILURE: '&c&l错误 | &7你不能将阶段等级设置为 {0}.'


### PR DESCRIPTION
Changes:
- Translated Polish language entries
- Added translations for module commands descriptions
- Added translations for module commands arguments
- Added translations for reload and save commands
- Fixed module command usage - missing / and improper handling when the oneblock label was already registered
- Fixed usage of the command registered in the main plugin
- Updated the help command list to match the format of the main plugin
- Added display of current and total blocks amount in the phase to the action bar message

Fixes #113 