### PR TITLE
Fixed falling after destroying OneBlock

### DIFF
--- a/src/main/java/com/bgsoftware/ssboneblock/listeners/BlocksListener.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/listeners/BlocksListener.java
@@ -50,6 +50,7 @@ public final class BlocksListener implements Listener {
         if (e.getClass().equals(FakeBlockBreakEvent.class))
             return;
 
+        Player player = e.getPlayer();
         Block block = e.getBlock();
         Location blockLocation = block.getLocation();
 
@@ -117,6 +118,17 @@ public final class BlocksListener implements Listener {
 
             if (barrierPlacement)
                 underBlock.setType(Material.AIR);
+
+            if (player.getLocation().getBlock().equals(block)) {
+                double playerY = player.getLocation().getY();
+                double blockTopY = block.getY() + 1;
+
+                if (playerY < blockTopY) {
+                    double y = 1 - (playerY - block.getY());
+                    player.teleport(player.getLocation().add(0, y, 0));
+                    player.setVelocity(new Vector(0, 0, 0));
+                }
+            }
         });
 
     }
@@ -129,18 +141,16 @@ public final class BlocksListener implements Listener {
         Location blockLocation = new Location(e.getLocation().getWorld(), e.getLocation().getBlockX(),
                 e.getLocation().getBlockY(), e.getLocation().getBlockZ());
 
-        WorldUtils.lookupOneBlock(blockLocation, (oneBlockLocation, island) -> {
-            Bukkit.getScheduler().runTaskLater(module.getPlugin(), () ->
-                    module.getPhasesHandler().runNextAction(island, null), 20L);
-        });
+        WorldUtils.lookupOneBlock(blockLocation, (oneBlockLocation, island) ->
+                Bukkit.getScheduler().runTaskLater(module.getPlugin(), () ->
+                        module.getPhasesHandler().runNextAction(island, null), 20L));
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onOneBlockBurn(BlockBurnEvent e) {
-        WorldUtils.lookupOneBlock(e.getBlock().getLocation(), (oneBlockLocation, island) -> {
-            Bukkit.getScheduler().runTaskLater(module.getPlugin(), () ->
-                    module.getPhasesHandler().runNextAction(island, null), 20L);
-        });
+        WorldUtils.lookupOneBlock(e.getBlock().getLocation(), (oneBlockLocation, island) ->
+                Bukkit.getScheduler().runTaskLater(module.getPlugin(), () ->
+                        module.getPhasesHandler().runNextAction(island, null), 20L));
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/src/main/java/com/bgsoftware/ssboneblock/listeners/BlocksListener.java
+++ b/src/main/java/com/bgsoftware/ssboneblock/listeners/BlocksListener.java
@@ -51,6 +51,7 @@ public final class BlocksListener implements Listener {
         if (e.getClass().equals(FakeBlockBreakEvent.class))
             return;
 
+        Player player = e.getPlayer();
         Block block = e.getBlock();
         Location blockLocation = block.getLocation();
 
@@ -118,6 +119,17 @@ public final class BlocksListener implements Listener {
 
             if (barrierPlacement)
                 underBlock.setType(Material.AIR);
+
+            if (player.getLocation().getBlock().equals(block)) {
+                double playerY = player.getLocation().getY();
+                double blockTopY = block.getY() + 1;
+
+                if (playerY < blockTopY) {
+                    double y = 1 - (playerY - block.getY());
+                    player.teleport(player.getLocation().add(0, y, 0));
+                    player.setVelocity(new Vector(0, 0, 0));
+                }
+            }
         });
 
     }


### PR DESCRIPTION
If oneblock generated a block of non-standard height and we destroyed it while standing on it, we would "fall" into it and fall into the void, so I added a protection that teleports the player above the block in such a situation